### PR TITLE
Update Setup NuGet Package action

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,10 +80,8 @@ jobs:
         - name: Setup MSBuild
           uses: microsoft/setup-msbuild@v1
           
-        - name: Setup NuGet
-          uses: NuGet/setup-nuget@v1.0.5
-          with:
-            nuget-version: 5.5.0
+        - name: Setup NuGet.exe for use with actions
+          uses: NuGet/setup-nuget@v1.2.0
 
         - name: Create Build Directory
           run: mkdir _build


### PR DESCRIPTION
This fix is proposed to resolve this exception:

Azure devops Nuget restore error SixLabors.ImageSharp.Web 2.0.2 is not compatible with net60 

Identified as an issue for some Umbraco users: https://our.umbraco.com/forum/using-umbraco-and-getting-started/110120-azure-devops-nuget-restore-error-sixlaborsimagesharpweb-202-is-not-compatible-with-net60